### PR TITLE
Fix inconsistent use of | in bra-ket notation

### DIFF
--- a/PH4401/scattering.ipynb
+++ b/PH4401/scattering.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "The Born series formula for the scattering amplitude, to second order and for 3D space, is\n",
     "\n",
-    "$$f(\\mathbf{k}_i\\rightarrow \\mathbf{k}_f) \\approx - \\frac{2m}{\\hbar^2} \\,\\cdot \\, 2\\pi^2 \\, \\Bigg[\\big\\langle \\mathbf{k}_f\\big| \\hat{V}|\\mathbf{k}_i\\big\\rangle + \\big\\langle \\mathbf{k}_f \\big| \\hat{V}\\hat{G}_0 \\hat{V} \\big|\\mathbf{k}_i\\big\\rangle + \\cdots \\Bigg].$$\n",
+    "$$f(\\mathbf{k}_i\\rightarrow \\mathbf{k}_f) \\approx - \\frac{2m}{\\hbar^2} \\,\\cdot \\, 2\\pi^2 \\, \\Bigg[\\big\\langle \\mathbf{k}_f\\big| \\hat{V}\\big|\\mathbf{k}_i\\big\\rangle + \\big\\langle \\mathbf{k}_f \\big| \\hat{V}\\hat{G}_0 \\hat{V} \\big|\\mathbf{k}_i\\big\\rangle + \\cdots \\Bigg].$$\n",
     "\n",
     "The particle mass is $m$, the scattering potential operator is $\\hat{V}$, and $|\\mathbf{k}\\rangle$ denotes a momentum eigenstate corresponding to wavevector $\\mathbf{k}$.  In the position basis,\n",
     "\n",
@@ -56,7 +56,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from scipy import *\n",
@@ -100,7 +102,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def sample_f1(Vfun, ki, kf, L):\n",
@@ -119,7 +123,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def sample_f2(Vfun, ki, kf, L):\n",
@@ -141,7 +147,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def V1(r):\n",
@@ -236,7 +244,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -272,7 +282,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Found some inconsistent use of "|" for the bra-ket notation after the line
> The Born series formula for the scattering amplitude, to second order and for 3D space, is

in PH4401/scattering.ipynb


Changed to the usual \big|