### PR TITLE
Riemann sum limit typo fix

### DIFF
--- a/MH2801/02_integrals.ipynb
+++ b/MH2801/02_integrals.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "If we have a function $f(x)$ which is well-defined for some $a \\le x \\le b $, its integral over those two values is defined as\n",
     "\n",
-    "$$\\int_a^b dx\\; f(x) \\;=\\; \\lim_{N \\rightarrow 0} \\, \\sum_{n=0}^{N} \\Delta x\\; f(x_n) \\;\\;\\;\\mathrm{where}\\;\\; x_n = a + n\\Delta x, \\;\\; \\Delta x \\equiv \\left(\\frac{b-a}{N}\\right).$$\n",
+    "$$\\int_a^b dx\\; f(x) \\;=\\; \\lim_{N \\rightarrow \\infty} \\, \\sum_{n=0}^{N} \\Delta x\\; f(x_n) \\;\\;\\;\\mathrm{where}\\;\\; x_n = a + n\\Delta x, \\;\\; \\Delta x \\equiv \\left(\\frac{b-a}{N}\\right).$$\n",
     "\n",
     "This is called a **definite integral**, and represents the area under the graph of $f(x)$ in the region between $x=a$ and $x=b$, as shown in the figure below.  The function $f(x)$ is called the **integrand**, and the two points $a$ and $b$ are called the **bounds** of the integral. The interval between the two bounds is divided into $N$ segments, of length $(b-a)/N$ each. Each term in the sum represents the area of a rectangle, and as $N\\rightarrow \\infty$, the sum converges to the area under the curve.\n",
     "\n",

--- a/latex/MH2801/02_integrals.tex
+++ b/latex/MH2801/02_integrals.tex
@@ -36,7 +36,7 @@
 If we have a function $f(x)$ which is well-defined for some $a \le x
 \le b$, its integral over those two values is defined as
 \begin{equation}
-  \int_a^b dx\; f(x) \;=\; \lim_{N \rightarrow 0} \, \sum_{n=0}^{N} \Delta x\; f(x_n) \;\;\;\mathrm{where}\;\; x_n = a + n\Delta x, \;\; \Delta x \equiv \left(\frac{b-a}{N}\right).
+  \int_a^b dx\; f(x) \;=\; \lim_{N \rightarrow \infty} \, \sum_{n=0}^{N} \Delta x\; f(x_n) \;\;\;\mathrm{where}\;\; x_n = a + n\Delta x, \;\; \Delta x \equiv \left(\frac{b-a}{N}\right).
 \end{equation}
 This is called a \textbf{definite integral}, and represents the area
 under the graph of $f(x)$ in the region between $x=a$ and $x=b$,


### PR DESCRIPTION
There was a typo in the definition of definite integral as limit of Riemann sum (MH2801/02_integrals).
The limit N -> 0 should be N -> infinity.